### PR TITLE
change schema condition

### DIFF
--- a/src/classes/schema/errors.lisp
+++ b/src/classes/schema/errors.lisp
@@ -5,7 +5,7 @@
            #:schema-coercion-failed
            #:schema-coercion-failed-value
            #:schema-coercion-failed-schema
-           #:schema-object-coercion-failed
+           #:schema-object-error
            #:schema-object-unpermmited-key
            #:schema-object-invalid-value
            #:schema-validation-failed))
@@ -22,19 +22,11 @@
                        value
                        schema)))))
 
-(define-condition schema-object-coercion-failed (schema-coercion-failed)
-  ((key :initarg :key
-        :reader schema-object-coercion-failed-key)))
-
-(define-condition schema-object-unpermmited-key (schema-object-coercion-failed)
-  ())
-
-(define-condition schema-object-invalid-value (schema-object-coercion-failed)
-  ())
-
 (define-condition schema-validation-failed (schema-error validation-failed)
-  ((value :initarg :value)
-   (schema :initarg :schema)
+  ((value :initarg :value
+          :reader schema-validation-failed-value)
+   (schema :initarg :schema
+           :reader schema-validation-failed-schema)
    (message :initarg :message
             :initform nil))
   (:report (lambda (condition stream)
@@ -43,3 +35,17 @@
                        value
                        schema
                        message)))))
+
+(define-condition schema-object-error (schema-error)
+  ((key :initarg :key
+        :reader schema-object-error-key)
+   (value :initarg :value
+          :reader schema-object-value)
+   (schema :initarg :schema
+           :reader schema-object-schema)))
+
+(define-condition schema-object-unpermmited-key (schema-object-error)
+  ())
+
+(define-condition schema-object-invalid-value (schema-object-error)
+  ())

--- a/tests/classes/schema/coerce.lisp
+++ b/tests/classes/schema/coerce.lisp
@@ -75,9 +75,10 @@
   (ok (equalp (coerce-data '(("name" . "fukamachi")) '(object
                                                        (("name" string))))
               '(("name" . "fukamachi"))))
-  (ok (signals (coerce-data '(("name" . 1)) '(object
-                                              (("name" string))))
-          'schema-coercion-failed))
+  (ok (signals (coerce-data '(("name" . 1))
+                            '(object
+                              (("name" string))))
+               'schema-object-invalid-value))
   (ok (equalp (coerce-data '(("hi" . "all"))
                            '(object
                              (("name" string))))
@@ -86,7 +87,7 @@
                             '(object
                               (("name" string))
                               :required ("name")))
-          'schema-validation-failed))
+               'schema-validation-failed))
 
   (testing "additionalProperties"
     (ok (equal (coerce-data '(("name" . "fukamachi")
@@ -101,7 +102,7 @@
                               '(object
                                 (("name" string))
                                 :additional-properties nil))
-            'schema-coercion-failed))
+                 'schema-object-unpermmited-key))
     (let ((data (coerce-data '(("name" . "fukamachi")
                                ("created-at" . "2019-04-30"))
                              '(object


### PR DESCRIPTION
schema-validation-failedやschema-coercion-failedとは別にschema-object-errorというコンディションを用意し、
coerce-dataでのオブジェクトのエラーはschema-object-errorから継承したコンディションを使うようにしました