### PR TITLE
change regex

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -119,7 +119,7 @@
 
 (defun email-format-p (string)
   (when (and (<= (length string) 256)
-             (ppcre:scan "\\A[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\\z" string))
+             (ppcre:scan "\\A[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\z" string))
     t))
 
 (defun uuid-format-p (string)


### PR DESCRIPTION
正規表現を一部変更してtarget-string中のピリオドを認識するようにしました。
例えば
```
(email-format-p "foo@foo@gmail.com")
(email-format-p "foo@gmail,com")
```
などの文字列についても`nil`を返すようにしました