### PR TITLE
Add almost-integer type to allow float "integers" with 0 in the decimal

### DIFF
--- a/src/classes/schema/coerce.lisp
+++ b/src/classes/schema/coerce.lisp
@@ -5,7 +5,8 @@
         #:apispec/utils
         #:parse-number)
   (:import-from #:apispec/classes/schema/core
-                #:parse-schema-definition)
+                #:parse-schema-definition
+                #:almost-integer)
   (:import-from #:apispec/classes/schema/validate
                 #:validate-data)
   (:import-from #:apispec/classes/schema/errors
@@ -62,7 +63,7 @@
 
 (defmethod coerce-data ((value cl:number) (schema number))
   (handler-case (typecase schema
-                  (integer (coerce value 'cl:integer))
+                  (integer (coerce value 'almost-integer))
                   (float (coerce value 'cl:float))
                   (double (coerce value 'cl:double-float))
                   (otherwise value))

--- a/src/classes/schema/core.lisp
+++ b/src/classes/schema/core.lisp
@@ -49,6 +49,7 @@
            #:json
 
            #:boolean
+           #:almost-integer
 
            #:array
            #:array-items
@@ -156,6 +157,16 @@
 
   (call-next-method))
 
+(defun check-almost-integer-p (number)
+  (or (integerp number)
+      (multiple-value-bind (n decimal)
+          (truncate number)
+        (declare (ignore n))
+        (= decimal 0))))
+
+(deftype almost-integer ()
+  `(satisfies check-almost-integer-p))
+
 (defun make-number-schema (class &rest initargs)
   (apply #'make-instance (find-schema class)
          (match initargs
@@ -172,7 +183,7 @@
      ,@(loop for type in '(number cl:number
                            float cl:float
                            double cl-user::double
-                           integer cl:integer)
+                           integer apispec/classes/schema/core:almost-integer)
              collect `(defmethod make-schema ((class (eql ',type)) &rest initargs)
                         (apply #'make-number-schema class initargs))))
 


### PR DESCRIPTION
The idea of this PR is to allow the integer type to support float point numbers with 0 as the decimal part, this would relax the validation and not raise an error when the client uses a non-valid CL integer.