### PR TITLE
Fix for uuid-format-p

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -123,7 +123,7 @@
     t))
 
 (defun uuid-format-p (string)
-  (when (ppcre:scan "\\A[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12}\\z"
+  (when (ppcre:scan "\\A[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12}\\z"
                     string)
     t))
 

--- a/tests/utils.lisp
+++ b/tests/utils.lisp
@@ -26,3 +26,8 @@
   (ok (typep (list (make-person :name "Eitaro"))
              '(proper-list person)))
   (ng (typep '(1) '(proper-list person))))
+
+(deftest uuid-format-p-tests
+  (ok (uuid-format-p "f7db18a1-e269-42bb-8a91-53e80a3f0760"))
+  (ok (uuid-format-p "37780C98-EEE4-49EC-997C-C75D3B36A0EC"))
+  (ng (uuid-format-p "invalid-uuid")))


### PR DESCRIPTION
The format of uuid should also allow upper case hexadecimal representations. See chapter 6.5.2 of the iso norm,  https://www.iso.org/obp/ui/fr/#iso:std:iso-iec:9834:-8:ed-3:v1:en